### PR TITLE
filter file to generate && rename svcClient to svcEmitter

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,10 +3,11 @@ package nevent
 import (
 	"context"
 	"fmt"
+	"sync"
+
 	pb "github.com/LilithGames/nevent/proto"
 	"github.com/nats-io/nats.go"
 	"google.golang.org/protobuf/proto"
-	"sync"
 )
 
 type clientOptions struct {

--- a/interceptor.go
+++ b/interceptor.go
@@ -3,8 +3,8 @@ package nevent
 import (
 	"context"
 
-	"github.com/nats-io/nats.go"
 	pb "github.com/LilithGames/nevent/proto"
+	"github.com/nats-io/nats.go"
 )
 
 type ServerEventHandler func(ctx context.Context, t pb.EventType, m *nats.Msg) (interface{}, error)
@@ -30,13 +30,12 @@ func FuncServerInterceptor(i ServerInterceptor) ServerOption {
 func ChainServerInterceptor(items ...ServerInterceptor) ServerInterceptor {
 	return func(next ServerEventHandler) ServerEventHandler {
 		current := next
-		for i := len(items)-1; i >= 0; i-- {
+		for i := len(items) - 1; i >= 0; i-- {
 			current = items[i](current)
 		}
 		return current
 	}
 }
-
 
 type ClientEventInvoker func(ctx context.Context, t pb.EventType, m *nats.Msg) (interface{}, error)
 type ClientInterceptor func(next ClientEventInvoker) ClientEventInvoker
@@ -50,7 +49,7 @@ func IdentityClientInterceptor() ClientInterceptor {
 }
 
 func FuncClientInterceptor(i ClientInterceptor) ClientOption {
-	return newFuncClientOption(func (o *clientOptions) {
+	return newFuncClientOption(func(o *clientOptions) {
 		o.interceptor = i
 	})
 }
@@ -58,7 +57,7 @@ func FuncClientInterceptor(i ClientInterceptor) ClientOption {
 func ChainClientInterceptor(items ...ClientInterceptor) ClientInterceptor {
 	return func(next ClientEventInvoker) ClientEventInvoker {
 		current := next
-		for i := len(items)-1; i >= 0; i-- {
+		for i := len(items) - 1; i >= 0; i-- {
 			current = items[i](current)
 		}
 		return current

--- a/protoc-gen-nevent/main.go
+++ b/protoc-gen-nevent/main.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 	pbfeatures := uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
-	g := pgs.Init(pgs.SupportedFeatures(&pbfeatures))
+	g := pgs.Init(pgs.DebugEnv("NEVENT_DEBUG"), pgs.SupportedFeatures(&pbfeatures))
 	g.RegisterModule(NewEvent())
 	g.RegisterPostProcessor(pgsgo.GoFmt())
 	g.Render()

--- a/protoc-gen-nevent/tmpl.go
+++ b/protoc-gen-nevent/tmpl.go
@@ -20,12 +20,12 @@ import (
 {{- $ssubject := default $soptions.Subject $svc }}
 {{- $bsubject := printf "%s.%s" $fsubject $ssubject }}
 
-type {{ $svc }}Client struct{
+type {{ $svc }}Emitter struct{
 	nc *nevent.Client
 }
 
-func New{{ $svc }}Client(nc *nevent.Client) *{{ $svc }}Client{
-	return &{{ $svc }}Client{nc: nc}
+func New{{ $svc }}Emitter(nc *nevent.Client) *{{ $svc }}Emitter{
+	return &{{ $svc }}Emitter{nc: nc}
 }
 {{- range .Methods }}
 {{- $oname := name .Output }}
@@ -57,7 +57,7 @@ func Register{{ name . }}(s *nevent.Server, handler {{ name . }}Listener, opts .
 	return s.ListenEvent("{{ $subject }}", pb.EventType_Event, eh, opts...)
 }
 
-func (it *{{ $svc }}Client){{ name . }}(ctx context.Context, e *{{ name .Input }}, opts ...nevent.EmitOption) error {
+func (it *{{ $svc }}Emitter){{ name . }}(ctx context.Context, e *{{ name .Input }}, opts ...nevent.EmitOption) error {
 	msg := nats.NewMsg("{{ $subject }}")
 	data, err := proto.Marshal(e)
 	if err != nil {
@@ -91,7 +91,7 @@ func Register{{ name . }}(s *nevent.Server, handler {{ name . }}Listener, opts .
 	return s.ListenEvent("{{ $subject }}", pb.EventType_Push, eh, opts...)
 }
 
-func (it *{{ $svc }}Client){{ name . }}(ctx context.Context, e *{{ name .Input }}, opts ...nevent.EmitOption) (*pb.PushAck, error) {
+func (it *{{ $svc }}Emitter){{ name . }}(ctx context.Context, e *{{ name .Input }}, opts ...nevent.EmitOption) (*pb.PushAck, error) {
 	msg := nats.NewMsg("{{ $subject }}")
 	data, err := proto.Marshal(e)
 	if err != nil {
@@ -135,7 +135,7 @@ func Register{{ name . }}(s *nevent.Server, handler {{ name . }}Listener, opts .
 	return s.ListenEvent("{{ $subject }}", pb.EventType_Ask, eh, opts...)
 }
 
-func (it *{{ $svc }}Client){{ name . }}(ctx context.Context, e *{{ name .Input }}, opts ...nevent.EmitOption) (*{{ name .Output }}, error) {
+func (it *{{ $svc }}Emitter){{ name . }}(ctx context.Context, e *{{ name .Input }}, opts ...nevent.EmitOption) (*{{ name .Output }}, error) {
 	msg := nats.NewMsg("{{ $subject }}")
 	data, err := proto.Marshal(e)
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -49,7 +49,6 @@ func ServerErrorHandler(f func(error)) ServerOption {
 	})
 }
 
-
 func ServerSubjectTransformer(ts SubjectTransformer) ServerOption {
 	return newFuncServerOption(func(o *serverOptions) {
 		o.subjectTransformer = ts

--- a/stream.go
+++ b/stream.go
@@ -96,10 +96,10 @@ func StreamSubjectNormalizer(subjectNormalizer SubjectNormalizer) StreamOption {
 }
 
 type streamOptions struct {
-	config *nats.StreamConfig
+	config             *nats.StreamConfig
 	subjectTransformer SubjectTransformer
-	subjectNormalizer SubjectNormalizer
-	force bool
+	subjectNormalizer  SubjectNormalizer
+	force              bool
 }
 
 type StreamOption interface {

--- a/subject.go
+++ b/subject.go
@@ -22,7 +22,7 @@ func PatternSubjectTransformer(pattern string) SubjectTransformer {
 }
 
 func STSubordinate(ns string) SubjectTransformer {
-	return PatternSubjectTransformer("%s."+ns)
+	return PatternSubjectTransformer("%s." + ns)
 }
 
 func STAny() SubjectTransformer {
@@ -52,4 +52,3 @@ func SubjectDenormalize(name string) string {
 	s = strings.Replace(s, "/", ".", -1)
 	return s
 }
-


### PR DESCRIPTION
1. filter the normal service without generating the nevent.go file, the current situation is that a go file that cannot be compiled will be generated
2. rename generated ServiceClient to ServiceEmitter, prevent client name duplication with protoc-gen-go-grpc
3. format go code with goimports